### PR TITLE
fix(vite-plugin-icons): Resolve sourcemap warning

### DIFF
--- a/packages/vite-plugin-icons/package.json
+++ b/packages/vite-plugin-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ch-ui/vite-plugin-icons",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Vite plugin for automating icon sprite bundling.",
   "bugs": "https://github.com/ch-ui-dev/ch-ui/issues",
   "authors": [

--- a/packages/vite-plugin-icons/src/index.ts
+++ b/packages/vite-plugin-icons/src/index.ts
@@ -81,7 +81,7 @@ export default function vitePluginChUiIcons(params: BundleParams): Plugin[] {
           await makeSprite(params, detectedSymbols);
           updated = false;
         }
-        return { code: src };
+        return { code: src, map: null };
       },
     },
   ] satisfies Plugin[];


### PR DESCRIPTION
This PR resolves an issue where using Rollup to bundle with this plugin emits a warning for every file processed about a missing sourcemap, though none is needed.