### PR TITLE
fix(tailwind-tokens): Facet disposition

### DIFF
--- a/packages/tailwind-tokens/package.json
+++ b/packages/tailwind-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ch-ui/tailwind-tokens",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A tokens system for a more malleable web.",
   "bugs": "https://github.com/ch-ui-dev/ch-ui/issues",
   "authors": [

--- a/packages/tailwind-tokens/package.json
+++ b/packages/tailwind-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ch-ui/tailwind-tokens",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A tokens system for a more malleable web.",
   "bugs": "https://github.com/ch-ui-dev/ch-ui/issues",
   "authors": [

--- a/packages/tailwind-tokens/test/sanity.spec.ts
+++ b/packages/tailwind-tokens/test/sanity.spec.ts
@@ -10,6 +10,18 @@ const testConfig: TailwindAdapterConfig = {
   colors: {
     facet: 'colors',
     disposition: 'overwrite',
+    tokenization: 'recursive',
+  },
+  borderWidth: {
+    facet: 'lengths',
+    disposition: 'extend',
+    tokenization: 'keep-series',
+    seriesValueSeparator: '/',
+  },
+  outlineWidth: {
+    facet: 'lengths',
+    disposition: 'extend',
+    tokenization: 'omit-series',
   },
 };
 
@@ -35,5 +47,13 @@ test('mapper returns valid tailwind theme extension partial', async () => {
   assert.equal(
     (result.colors as Record<string, string>)['bg-html'],
     'var(--ch-bg-html)',
+  );
+  assert.equal(
+    (result.extend?.borderWidth as Record<string, string>)['gap/half'],
+    'var(--ch-gap-half)',
+  );
+  assert.equal(
+    (result.extend?.outlineWidth as Record<string, string>)['hairline'],
+    'var(--ch-gap-hairline)',
   );
 });


### PR DESCRIPTION
This PR implements one way `tailwind-tokens` can work with Tailwind’s different theme types. Notably, it does not yet include support for the font size theme types.