### PR TITLE
Add dry-run function to `vite-plugin-icons`

### DIFF
--- a/packages/vite-plugin-icons/package.json
+++ b/packages/vite-plugin-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ch-ui/vite-plugin-icons",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "description": "Vite plugin for automating icon sprite bundling.",
   "bugs": "https://github.com/ch-ui-dev/ch-ui/issues",
@@ -23,8 +23,20 @@
       "import": "./dist/index.js",
       "types": "./dist/src/index.d.ts"
     },
+    "./validate": {
+      "require": "./dist/validate.cjs",
+      "import": "./dist/validate.js",
+      "types": "./dist/src/validate.d.ts"
+    },
     "./README.md": {
       "import": "./README.md"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "validate": [
+        "./dist/src/validate.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/vite-plugin-icons/project.json
+++ b/packages/vite-plugin-icons/project.json
@@ -6,9 +6,9 @@
   "targets": {
     "build": {
       "command": "rm packages/vite-plugin-icons/dist/package.json",
-      "dependsOn": ["preBuild"]
+      "dependsOn": ["preBuildPlugin", "preBuildValidate"]
     },
-    "preBuild": {
+    "preBuildPlugin": {
       "executor": "@nx/esbuild:esbuild",
       "options": {
         "external": ["@ch-ui/icons", "picomatch"],
@@ -22,6 +22,24 @@
       },
       "dependsOn": ["^build"],
       "outputs": ["{options.outputPath}"]
+    },
+    "preBuildValidate": {
+      "executor": "@nx/esbuild:esbuild",
+      "options": {
+        "external": ["@ch-ui/icons"],
+        "main": "{projectRoot}/src/validate.ts",
+        "outputPath": "{projectRoot}/dist",
+        "tsConfig": "{projectRoot}/tsconfig.json",
+        "format": ["cjs", "esm"],
+        "declarationRootDir": "{projectRoot}",
+        "sourcemap": true,
+        "generatePackageJson": false
+      },
+      "dependsOn": ["^build"],
+      "outputs": ["{options.outputPath}"]
+    },
+    "test": {
+      "command": "cd packages/vite-plugin-icons && tsx ./test/validate.spec.ts"
     },
     "lint": {}
   }

--- a/packages/vite-plugin-icons/src/validate.ts
+++ b/packages/vite-plugin-icons/src/validate.ts
@@ -1,0 +1,87 @@
+// Required notice: Copyright (c) 2024, Will Shown <ch-ui@willshown.com>
+
+import { scanString, type BundleParams } from '@ch-ui/icons';
+import fg from 'fast-glob';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export type ValidateIconsParams = Pick<
+  BundleParams,
+  'symbolPattern' | 'assetPath' | 'contentPaths'
+> & { verbose?: boolean };
+
+export type ValidateIconsResult = {
+  symbols: Set<string>;
+  missing: { symbol: string; expectedPath: string }[];
+};
+
+const LABEL = 'validateIcons';
+
+export const validateIcons = ({
+  symbolPattern,
+  assetPath,
+  contentPaths,
+  verbose,
+}: ValidateIconsParams): ValidateIconsResult => {
+  const symbols = new Set<string>();
+
+  if (verbose) {
+    console.log(`[${LABEL}] Scanning content globs for icon patterns...`);
+  }
+
+  for (const contentPath of contentPaths) {
+    const files = fg.sync(contentPath, { absolute: true });
+
+    if (verbose) {
+      console.log(
+        `[${LABEL}] Found ${files.length} files matching ${contentPath}`,
+      );
+    }
+
+    for (const file of files) {
+      try {
+        const src = readFileSync(file, 'utf8');
+        const candidates = scanString({
+          contentString: src,
+          symbolPattern,
+        });
+        for (const candidate of candidates) {
+          symbols.add(candidate);
+        }
+      } catch (err) {
+        if (verbose) {
+          console.warn(`[${LABEL}] Could not read file: ${file}`, err);
+        }
+      }
+    }
+  }
+
+  if (verbose) {
+    console.log(`[${LABEL}] Total detected symbols: ${symbols.size}`);
+  }
+
+  const symbolExp = new RegExp(symbolPattern);
+  const missing: ValidateIconsResult['missing'] = [];
+
+  for (const symbol of symbols) {
+    const match = symbol.match(symbolExp);
+    if (match && match[1] && match[2]) {
+      const [, ...groups] = match;
+      const expectedPath = resolve(assetPath(...groups));
+      if (!existsSync(expectedPath)) {
+        missing.push({ symbol, expectedPath });
+      }
+    } else {
+      missing.push({ symbol, expectedPath: `(unresolvable: ${symbol})` });
+    }
+  }
+
+  if (verbose && missing.length > 0) {
+    console.log(`[${LABEL}] Missing assets:`);
+    for (const { symbol, expectedPath } of missing) {
+      console.log(`[${LABEL}]   ${symbol} -> ${expectedPath}`);
+    }
+  }
+
+  return { symbols, missing };
+};

--- a/packages/vite-plugin-icons/test/validate.spec.ts
+++ b/packages/vite-plugin-icons/test/validate.spec.ts
@@ -1,0 +1,69 @@
+// Required notice: Copyright (c) 2024, Will Shown <ch-ui@willshown.com>
+
+import assert from 'node:assert';
+import test from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateIcons } from '../src/validate';
+
+// @ts-ignore
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const symbolPattern =
+  'ph--([a-z]+[a-z-]*)--(bold|duotone|fill|light|regular|thin)';
+
+const assetPath = (name: string, variant: string) =>
+  resolve(
+    __dirname,
+    `../../icons/node_modules/@phosphor-icons/core/assets/${variant}/${name}${
+      variant === 'regular' ? '' : `-${variant}`
+    }.svg`,
+  );
+
+test('validates icons in content files with no missing assets', () => {
+  const result = validateIcons({
+    symbolPattern,
+    assetPath,
+    contentPaths: [resolve(__dirname, '../src/icons.stories.ts')],
+  });
+
+  assert.ok(result.symbols.size > 0, 'should detect at least one symbol');
+  assert.equal(
+    result.missing.length,
+    0,
+    `expected no missing assets but found: ${result.missing
+      .map((m) => `${m.symbol} -> ${m.expectedPath}`)
+      .join(', ')}`,
+  );
+});
+
+test('reports missing assets when asset path is wrong', () => {
+  const result = validateIcons({
+    symbolPattern,
+    assetPath: (name, variant) =>
+      resolve(__dirname, `./nonexistent/${variant}/${name}.svg`),
+    contentPaths: [resolve(__dirname, '../src/icons.stories.ts')],
+  });
+
+  assert.ok(result.symbols.size > 0, 'should detect at least one symbol');
+  assert.equal(
+    result.missing.length,
+    result.symbols.size,
+    'all symbols should be missing when asset path is wrong',
+  );
+  for (const entry of result.missing) {
+    assert.ok(entry.symbol, 'missing entry should have a symbol');
+    assert.ok(entry.expectedPath, 'missing entry should have an expectedPath');
+  }
+});
+
+test('returns empty results when no content files match', () => {
+  const result = validateIcons({
+    symbolPattern,
+    assetPath,
+    contentPaths: [resolve(__dirname, './nonexistent-glob-*.ts')],
+  });
+
+  assert.equal(result.symbols.size, 0, 'should detect no symbols');
+  assert.equal(result.missing.length, 0, 'should have no missing assets');
+});


### PR DESCRIPTION
This PR adds a function for performing a dry-run of the icon bundler so a check can be performed in e.g. lint scripts without having to run a build or produce a sprite.